### PR TITLE
Add NavigationTransitionInfo to NavigationServiceEx

### DIFF
--- a/dev/Core/NavigationService/Contracts/Services/INavigationServiceEx.cs
+++ b/dev/Core/NavigationService/Contracts/Services/INavigationServiceEx.cs
@@ -1,4 +1,6 @@
-﻿namespace WinUICommunity;
+﻿using Microsoft.UI.Xaml.Media.Animation;
+
+namespace WinUICommunity;
 
 public interface INavigationServiceEx
 {
@@ -19,7 +21,8 @@ public interface INavigationServiceEx
         get; set;
     }
 
-    bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false);
+    bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false, NavigationTransitionInfo transitionInfo = null);
+    bool NavigateTo(Type pageType, object? parameter = null, bool clearNavigation = false, NavigationTransitionInfo transitionInfo = null);
 
     bool GoBack();
 }

--- a/dev/Core/NavigationService/Services/NavigationServiceEx.cs
+++ b/dev/Core/NavigationService/Services/NavigationServiceEx.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.UI.Xaml.Media.Animation;
+
 namespace WinUICommunity;
 
 public class NavigationServiceEx : INavigationServiceEx
@@ -74,15 +76,29 @@ public class NavigationServiceEx : INavigationServiceEx
         return false;
     }
 
-    public bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false)
+    public bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false, NavigationTransitionInfo transitionInfo = null)
     {
         var pageType = _pageService.GetPageType(pageKey);
+        return Navigate(pageType, parameter, clearNavigation, transitionInfo);
+    }
+
+    public bool NavigateTo(Type pageType, object? parameter = null, bool clearNavigation = false, NavigationTransitionInfo transitionInfo = null)
+    {
+        return Navigate(pageType, parameter, clearNavigation, transitionInfo);
+    }
+
+    public bool Navigate(Type pageType, object? parameter = null, bool clearNavigation = false, NavigationTransitionInfo transitionInfo = null)
+    {
+        if (pageType == null)
+        {
+            return false;
+        }
 
         if (_frame != null && (_frame.Content?.GetType() != pageType || (parameter != null && !parameter.Equals(_lastParameterUsed))))
         {
             _frame.Tag = clearNavigation;
             var vmBeforeNavigation = _frame.GetPageViewModel();
-            var navigated = _frame.Navigate(pageType, parameter);
+            var navigated = _frame.Navigate(pageType, parameter, transitionInfo);
             if (navigated)
             {
                 _lastParameterUsed = parameter;


### PR DESCRIPTION
Add NavigationTransitionInfo to NavigationServiceEx to allow custom transitions like the JsonNavigationViewService. 